### PR TITLE
fix on ticker event with the new Ticker model

### DIFF
--- a/lib/transports/ws2.js
+++ b/lib/transports/ws2.js
@@ -530,7 +530,9 @@ class WSv2 extends EventEmitter {
    * @private
    */
   _handleTickerMessage (msg, chanData) {
-    const data = this._transform ? Tick.unserialize(msg[2]) : msg[2]
+    const tempMsg = msg[1].splice(0);
+		tempMsg.unshift(chanData.symbol);
+		const data = this._transform ? Tick.unserialize(tempMsg) : tempMsg;
     const internalMessage = [chanData.chanId, 'ticker', data]
     internalMessage.filterOverride = [chanData.symbol]
 


### PR DESCRIPTION
With the last update and introduction of Models, WSv2.onTicker is broken. The change fixes it and uses the same transform code as the rest interface.